### PR TITLE
Sending test properties in TestItemFinishedEventArgs

### DIFF
--- a/ReportPortal.NUnitExtension/EventArguments/TestItemFinishedEventArgs.cs
+++ b/ReportPortal.NUnitExtension/EventArguments/TestItemFinishedEventArgs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using ReportPortal.Client;
 using ReportPortal.Client.Requests;
 using ReportPortal.Shared;
@@ -7,19 +8,21 @@ namespace ReportPortal.NUnitExtension.EventArguments
 {
     public class TestItemFinishedEventArgs : EventArgs
     {
-        public TestItemFinishedEventArgs(Service service, FinishTestItemRequest request, TestReporter testReporter)
+        public TestItemFinishedEventArgs(Service service, FinishTestItemRequest request, TestReporter testReporter, Dictionary<string, string> properties)
         {
             Service = service;
             TestItem = request;
             TestReporter = testReporter;
+            Properties = properties;
         }
 
         public Service Service { get; }
 
         public FinishTestItemRequest TestItem { get; }
-
-
+        
         public TestReporter TestReporter { get; }
+
+        public Dictionary<string, string> Properties { get; }
 
         public bool Canceled { get; set; }
     }

--- a/ReportPortal.NUnitExtension/EventArguments/TestItemFinishedEventArgs.cs
+++ b/ReportPortal.NUnitExtension/EventArguments/TestItemFinishedEventArgs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Xml;
 using ReportPortal.Client;
 using ReportPortal.Client.Requests;
 using ReportPortal.Shared;
@@ -8,12 +9,12 @@ namespace ReportPortal.NUnitExtension.EventArguments
 {
     public class TestItemFinishedEventArgs : EventArgs
     {
-        public TestItemFinishedEventArgs(Service service, FinishTestItemRequest request, TestReporter testReporter, Dictionary<string, string> properties)
+        public TestItemFinishedEventArgs(Service service, FinishTestItemRequest request, TestReporter testReporter, string report)
         {
             Service = service;
             TestItem = request;
             TestReporter = testReporter;
-            Properties = properties;
+            Report = report;
         }
 
         public Service Service { get; }
@@ -22,7 +23,7 @@ namespace ReportPortal.NUnitExtension.EventArguments
         
         public TestReporter TestReporter { get; }
 
-        public Dictionary<string, string> Properties { get; }
+        public string Report { get; }
 
         public bool Canceled { get; set; }
     }

--- a/ReportPortal.NUnitExtension/ReportPortalListener.Suite.cs
+++ b/ReportPortal.NUnitExtension/ReportPortalListener.Suite.cs
@@ -120,17 +120,7 @@ namespace ReportPortal.NUnitExtension
                             finishSuiteRequest.Description = description.Attributes["value"].Value;
                         }
 
-                        var properties = new Dictionary<string, string>();
-                        var propertiesNodes = xmlDoc.SelectNodes("//properties/property");
-                        if (propertiesNodes != null)
-                        {
-                            foreach (XmlNode propertyNode in propertiesNodes)
-                            {
-                                properties.Add(propertyNode.Attributes["name"].Value, propertyNode.Attributes["value"].Value);
-                            }
-                        }
-
-                        var eventArg = new TestItemFinishedEventArgs(Bridge.Service, finishSuiteRequest, _flowItems[id].Reporter, properties);
+                        var eventArg = new TestItemFinishedEventArgs(Bridge.Service, finishSuiteRequest, _flowItems[id].Reporter, xmlDoc.InnerXml);
 
                         try
                         {
@@ -145,7 +135,7 @@ namespace ReportPortal.NUnitExtension
 
                         try
                         {
-                            AfterSuiteFinished?.Invoke(this, new TestItemFinishedEventArgs(Bridge.Service, finishSuiteRequest, _flowItems[id].Reporter, properties));
+                            AfterSuiteFinished?.Invoke(this, new TestItemFinishedEventArgs(Bridge.Service, finishSuiteRequest, _flowItems[id].Reporter, xmlDoc.InnerXml));
                         }
                         catch (Exception exp)
                         {

--- a/ReportPortal.NUnitExtension/ReportPortalListener.Suite.cs
+++ b/ReportPortal.NUnitExtension/ReportPortalListener.Suite.cs
@@ -120,7 +120,7 @@ namespace ReportPortal.NUnitExtension
                             finishSuiteRequest.Description = description.Attributes["value"].Value;
                         }
 
-                        var eventArg = new TestItemFinishedEventArgs(Bridge.Service, finishSuiteRequest, _flowItems[id].Reporter, xmlDoc.InnerXml);
+                        var eventArg = new TestItemFinishedEventArgs(Bridge.Service, finishSuiteRequest, _flowItems[id].Reporter, xmlDoc.OuterXml);
 
                         try
                         {
@@ -135,7 +135,7 @@ namespace ReportPortal.NUnitExtension
 
                         try
                         {
-                            AfterSuiteFinished?.Invoke(this, new TestItemFinishedEventArgs(Bridge.Service, finishSuiteRequest, _flowItems[id].Reporter, xmlDoc.InnerXml));
+                            AfterSuiteFinished?.Invoke(this, new TestItemFinishedEventArgs(Bridge.Service, finishSuiteRequest, _flowItems[id].Reporter, xmlDoc.OuterXml));
                         }
                         catch (Exception exp)
                         {

--- a/ReportPortal.NUnitExtension/ReportPortalListener.Suite.cs
+++ b/ReportPortal.NUnitExtension/ReportPortalListener.Suite.cs
@@ -120,7 +120,17 @@ namespace ReportPortal.NUnitExtension
                             finishSuiteRequest.Description = description.Attributes["value"].Value;
                         }
 
-                        var eventArg = new TestItemFinishedEventArgs(Bridge.Service, finishSuiteRequest, _flowItems[id].Reporter);
+                        var properties = new Dictionary<string, string>();
+                        var propertiesNodes = xmlDoc.SelectNodes("//properties/property");
+                        if (propertiesNodes != null)
+                        {
+                            foreach (XmlNode propertyNode in propertiesNodes)
+                            {
+                                properties.Add(propertyNode.Attributes["name"].Value, propertyNode.Attributes["value"].Value);
+                            }
+                        }
+
+                        var eventArg = new TestItemFinishedEventArgs(Bridge.Service, finishSuiteRequest, _flowItems[id].Reporter, properties);
 
                         try
                         {
@@ -135,7 +145,7 @@ namespace ReportPortal.NUnitExtension
 
                         try
                         {
-                            AfterSuiteFinished?.Invoke(this, new TestItemFinishedEventArgs(Bridge.Service, finishSuiteRequest, _flowItems[id].Reporter));
+                            AfterSuiteFinished?.Invoke(this, new TestItemFinishedEventArgs(Bridge.Service, finishSuiteRequest, _flowItems[id].Reporter, properties));
                         }
                         catch (Exception exp)
                         {

--- a/ReportPortal.NUnitExtension/ReportPortalListener.Test.cs
+++ b/ReportPortal.NUnitExtension/ReportPortalListener.Test.cs
@@ -215,7 +215,17 @@ namespace ReportPortal.NUnitExtension
                         finishTestRequest.IsRetry = true;
                     }
 
-                    var eventArg = new TestItemFinishedEventArgs(Bridge.Service, finishTestRequest, _flowItems[id].Reporter);
+                    var properties = new Dictionary<string, string>();
+                    var propertiesNodes = xmlDoc.SelectNodes("//properties/property");
+                    if (propertiesNodes != null)
+                    {
+                        foreach (XmlNode propertyNode in propertiesNodes)
+                        {
+                            properties.Add(propertyNode.Attributes["name"].Value, propertyNode.Attributes["value"].Value);
+                        }
+                    }
+
+                    var eventArg = new TestItemFinishedEventArgs(Bridge.Service, finishTestRequest, _flowItems[id].Reporter, properties);
 
                     try
                     {
@@ -230,7 +240,7 @@ namespace ReportPortal.NUnitExtension
 
                     try
                     {
-                        AfterTestFinished?.Invoke(this, new TestItemFinishedEventArgs(Bridge.Service, finishTestRequest, _flowItems[id].Reporter));
+                        AfterTestFinished?.Invoke(this, new TestItemFinishedEventArgs(Bridge.Service, finishTestRequest, _flowItems[id].Reporter, properties));
                     }
                     catch (Exception exp)
                     {

--- a/ReportPortal.NUnitExtension/ReportPortalListener.Test.cs
+++ b/ReportPortal.NUnitExtension/ReportPortalListener.Test.cs
@@ -215,17 +215,7 @@ namespace ReportPortal.NUnitExtension
                         finishTestRequest.IsRetry = true;
                     }
 
-                    var properties = new Dictionary<string, string>();
-                    var propertiesNodes = xmlDoc.SelectNodes("//properties/property");
-                    if (propertiesNodes != null)
-                    {
-                        foreach (XmlNode propertyNode in propertiesNodes)
-                        {
-                            properties.Add(propertyNode.Attributes["name"].Value, propertyNode.Attributes["value"].Value);
-                        }
-                    }
-
-                    var eventArg = new TestItemFinishedEventArgs(Bridge.Service, finishTestRequest, _flowItems[id].Reporter, properties);
+                    var eventArg = new TestItemFinishedEventArgs(Bridge.Service, finishTestRequest, _flowItems[id].Reporter, xmlDoc.InnerXml);
 
                     try
                     {
@@ -240,7 +230,7 @@ namespace ReportPortal.NUnitExtension
 
                     try
                     {
-                        AfterTestFinished?.Invoke(this, new TestItemFinishedEventArgs(Bridge.Service, finishTestRequest, _flowItems[id].Reporter, properties));
+                        AfterTestFinished?.Invoke(this, new TestItemFinishedEventArgs(Bridge.Service, finishTestRequest, _flowItems[id].Reporter, xmlDoc.InnerXml));
                     }
                     catch (Exception exp)
                     {

--- a/ReportPortal.NUnitExtension/ReportPortalListener.Test.cs
+++ b/ReportPortal.NUnitExtension/ReportPortalListener.Test.cs
@@ -215,7 +215,7 @@ namespace ReportPortal.NUnitExtension
                         finishTestRequest.IsRetry = true;
                     }
 
-                    var eventArg = new TestItemFinishedEventArgs(Bridge.Service, finishTestRequest, _flowItems[id].Reporter, xmlDoc.InnerXml);
+                    var eventArg = new TestItemFinishedEventArgs(Bridge.Service, finishTestRequest, _flowItems[id].Reporter, xmlDoc.OuterXml);
 
                     try
                     {
@@ -230,7 +230,7 @@ namespace ReportPortal.NUnitExtension
 
                     try
                     {
-                        AfterTestFinished?.Invoke(this, new TestItemFinishedEventArgs(Bridge.Service, finishTestRequest, _flowItems[id].Reporter, xmlDoc.InnerXml));
+                        AfterTestFinished?.Invoke(this, new TestItemFinishedEventArgs(Bridge.Service, finishTestRequest, _flowItems[id].Reporter, xmlDoc.OuterXml));
                     }
                     catch (Exception exp)
                     {


### PR DESCRIPTION
There is quit a lot of properties in test (see PropertyAttribute in NUnit), would be good to handle them in customization. 
